### PR TITLE
Refactor request handling to use OneOf for results

### DIFF
--- a/RequesterMini.csproj
+++ b/RequesterMini.csproj
@@ -25,5 +25,6 @@
     <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.10" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
+    <PackageReference Include="OneOf" Version="3.0.271" />
   </ItemGroup>
 </Project>

--- a/Utils/MakeRequest.cs
+++ b/Utils/MakeRequest.cs
@@ -1,3 +1,4 @@
+using OneOf;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
@@ -26,54 +27,62 @@ public class MakeRequest {
         _headers=headers ?? new Dictionary<string, string>();
     }
 
-    public async  Task<(string statusCode,string response, DateTime? FinishedTime)> Execute()
+    public async Task<OneOf<RequestSuccess, RequestFailure>> Execute()
     {
-        HttpMethod method = new HttpMethod(_httpMethod);
-
-        var request = new HttpRequestMessage(method, _url);
-
-        HttpContent content;
-        switch (_methodBodyType.ToLowerInvariant())
+        try
         {
-            case "json":
-                content = new StringContent(_methodBody, Encoding.UTF8, "application/json");
-                break;
-            case "xml":
-                content = new StringContent(_methodBody, Encoding.UTF8, "application/xml");
-                break;
-            case "form":
-                var formData = new MultipartFormDataContent();
-                formData.Add(new StringContent(_methodBody), "fieldName");
-                content = formData;
-                break;
-            default:
-                content = new StringContent(_methodBody);
-                break;
-        }
-        request.Content = content;
+            HttpMethod method = new HttpMethod(_httpMethod);
 
-        // Add custom headers after content is set
-        foreach (var header in _headers)
-        {
-            if (!string.IsNullOrWhiteSpace(header.Key))
+            var request = new HttpRequestMessage(method, _url);
+
+            HttpContent content;
+            switch (_methodBodyType.ToLowerInvariant())
             {
-                // Content-related headers should be added to Content.Headers
-                if (IsContentHeader(header.Key))
+                case "json":
+                    content = new StringContent(_methodBody, Encoding.UTF8, "application/json");
+                    break;
+                case "xml":
+                    content = new StringContent(_methodBody, Encoding.UTF8, "application/xml");
+                    break;
+                case "form":
+                    var formData = new MultipartFormDataContent();
+                    formData.Add(new StringContent(_methodBody), "fieldName");
+                    content = formData;
+                    break;
+                default:
+                    content = new StringContent(_methodBody);
+                    break;
+            }
+            request.Content = content;
+
+            // Add custom headers after content is set
+            foreach (var header in _headers)
+            {
+                if (!string.IsNullOrWhiteSpace(header.Key))
                 {
-                    request.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
-                }
-                else
-                {
-                    request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    // Content-related headers should be added to Content.Headers
+                    if (IsContentHeader(header.Key))
+                    {
+                        request.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    }
+                    else
+                    {
+                        request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    }
                 }
             }
+
+            var response = await _httpClient.SendAsync(request);
+
+            string responseContent = await response.Content.ReadAsStringAsync();
+
+            return new RequestSuccess(response.StatusCode.ToString(), responseContent, null);
         }
 
-        var response = await _httpClient.SendAsync(request);
-
-        string responseContent = await response.Content.ReadAsStringAsync();
-
-        return (response.StatusCode.ToString(),responseContent,null);
+        catch (Exception ex)
+        {
+            return new RequestFailure("An error occurred while making the request.", ex);
+        }
     }
 
     private static bool IsContentHeader(string headerName)
@@ -96,3 +105,7 @@ public class MakeRequest {
         return contentHeaders.Contains(headerName);
     }
 }
+
+public sealed record RequestSuccess(string StatusCode, string ResponseBody, DateTime? FinishedTimeUtc);
+
+public sealed record RequestFailure(string Message, Exception? Exception = null);

--- a/Utils/MakeRequest.cs
+++ b/Utils/MakeRequest.cs
@@ -81,7 +81,8 @@ public class MakeRequest {
 
         catch (Exception ex)
         {
-            return new RequestFailure("An error occurred while making the request.", ex);
+            var errorMessage = $"Error while making {_httpMethod} request to {_url}: {ex.Message}";
+            return new RequestFailure(errorMessage, ex);
         }
     }
 


### PR DESCRIPTION
Replaced tuple-based result in MakeRequest.Execute with OneOf, introducing RequestSuccess and RequestFailure records for clearer success/error handling. Updated MainWindowViewModel to process results using OneOf's Switch method. Added exception handling to MakeRequest. Minor formatting improvements included. Added OneOf NuGet package dependency.