### PR TITLE
Add request timing and finished time display

### DIFF
--- a/Models/RequestFailure.cs
+++ b/Models/RequestFailure.cs
@@ -1,0 +1,5 @@
+using System;
+
+namespace RequesterMini.Models;
+
+public sealed record RequestFailure(string Message, Exception? Exception = null);

--- a/Models/RequestSuccess.cs
+++ b/Models/RequestSuccess.cs
@@ -1,0 +1,5 @@
+using System;
+
+namespace RequesterMini.Models;
+
+public sealed record RequestSuccess(string StatusCode, string ResponseBody, DateTime? FinishedTimeUtc, TimeSpan? RequestTime);

--- a/RequesterMini.csproj
+++ b/RequesterMini.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Models\" />
     <AvaloniaResource Include="Assets\**" />
   </ItemGroup>
 

--- a/Utils/Timers/IElapsedTimer.cs
+++ b/Utils/Timers/IElapsedTimer.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace RequesterMini.Utils.Timers;
+
+public interface IElapsedTimer
+{
+    TimeSpan Elapsed { get; }
+    void Stop();
+}

--- a/Utils/Timers/IElapsedTimerFactory.cs
+++ b/Utils/Timers/IElapsedTimerFactory.cs
@@ -1,0 +1,6 @@
+namespace RequesterMini.Utils.Timers;
+
+public interface IElapsedTimerFactory
+{
+    IElapsedTimer StartNew();
+}

--- a/Utils/Timers/StopwatchTimer.cs
+++ b/Utils/Timers/StopwatchTimer.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Diagnostics;
+
+namespace RequesterMini.Utils.Timers;
+
+public sealed class StopwatchTimer(Stopwatch stopwatch) : IElapsedTimer
+{
+    public TimeSpan Elapsed => stopwatch.Elapsed;
+    public void Stop() => stopwatch.Stop();
+}

--- a/Utils/Timers/StopwatchTimerFactory.cs
+++ b/Utils/Timers/StopwatchTimerFactory.cs
@@ -1,0 +1,8 @@
+using System.Diagnostics;
+
+namespace RequesterMini.Utils.Timers;
+
+public sealed class StopwatchTimerFactory : IElapsedTimerFactory
+{
+    public IElapsedTimer StartNew() => new StopwatchTimer(Stopwatch.StartNew());
+}

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using RequesterMini.Constants;
 using System.Text.Json;
 using RequesterMini.Utils;
+using RequesterMini.Models;
 using OneOf;
 
 namespace RequesterMini.ViewModels;
@@ -54,6 +55,22 @@ public class MainWindowViewModel : ViewModelBase
         }
     } = "";
 
+    internal string FinishedTimeUtc
+    {
+        get;
+        set =>
+            this.RaiseAndSetIfChanged(ref
+                field, value);
+    } = "";
+
+    internal string RequestTime
+    {
+        get;
+        set =>
+            this.RaiseAndSetIfChanged(ref
+                field, value);
+    } = "";
+
     internal string SelectedHttpMethod
     {
         get;
@@ -95,11 +112,19 @@ public class MainWindowViewModel : ViewModelBase
                   {
                   ResponseBody = success.ResponseBody;
                   ResponseStatusCode = success.StatusCode;
+                  FinishedTimeUtc = success.FinishedTimeUtc?.ToString("yyyy-MM-dd HH:mm:ss") + " UTC";
+                  RequestTime = success.RequestTime is { } elapsed
+                      ? elapsed.TotalSeconds < 1
+                          ? $"{elapsed.TotalMilliseconds:F0} ms"
+                          : $"{elapsed.TotalSeconds:F1} sec"
+                      : "";
                  },
              failure =>
              {
                 ResponseBody = failure.Message;
                 ResponseStatusCode = "Error";
+                FinishedTimeUtc = "";
+                RequestTime = "";
              });
 
 

--- a/Views/MainWindow.axaml
+++ b/Views/MainWindow.axaml
@@ -101,9 +101,19 @@
                         CornerRadius="4" 
                         Padding="10" 
                         Margin="0,0,0,10">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="Status:" FontWeight="Bold" Margin="0,0,5,0"/>
-                        <TextBlock Text="{Binding ResponseStatusCode}" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundAccentBrush}"/>
+                    <StackPanel Orientation="Horizontal" Spacing="15">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="Status:" FontWeight="Bold" Margin="0,0,5,0"/>
+                            <TextBlock Text="{Binding ResponseStatusCode}" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundAccentBrush}"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="Finished:" FontWeight="Bold" Margin="0,0,5,0"/>
+                            <TextBlock Text="{Binding FinishedTimeUtc}" Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="Time:" FontWeight="Bold" Margin="0,0,5,0"/>
+                            <TextBlock Text="{Binding RequestTime}" Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        </StackPanel>
                     </StackPanel>
                 </Border>
                 


### PR DESCRIPTION
Introduce timer abstraction to measure HTTP request duration. Update MakeRequest to record and return timing info. Show finished time and request duration in UI and ViewModel. Move RequestSuccess/Failure to Models namespace.
Remove explicit Models folder entry from project file.