### PR TITLE
Add request cancellation support to UI and HTTP workflow

### DIFF
--- a/Views/MainWindow.axaml
+++ b/Views/MainWindow.axaml
@@ -42,11 +42,16 @@
                          VerticalAlignment="Center"
                          Margin="0,0,10,0"/>
                 
-                <Button Grid.Column="2" 
-                        Classes="primary" 
-                        Command="{Binding ClickCommand}" 
-                        Content="Send"
-                        VerticalAlignment="Center"/>
+                <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="5">
+                    <Button Classes="primary" 
+                            Command="{Binding ClickCommand}" 
+                            Content="Send"
+                            VerticalAlignment="Center"/>
+                    <Button Classes="danger" 
+                            Command="{Binding CancelCommand}" 
+                            Content="Cancel"
+                            VerticalAlignment="Center"/>
+                </StackPanel>
             </Grid>
 
             <!-- Request Details (Tabs) -->


### PR DESCRIPTION
Implemented cancellation for HTTP requests via a new Cancel button in the UI. Refactored MakeRequest to accept a CancellationToken and handle OperationCanceledException. MainWindowViewModel now manages a CancellationTokenSource and exposes a CancelCommand to allow users to cancel in-progress requests, improving responsiveness and user control.