### PR TITLE
Persist old requests and harden storage against IO failures

### DIFF
--- a/JsonFileStore.Tests/JsonFileStore.Tests.csproj
+++ b/JsonFileStore.Tests/JsonFileStore.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\JsonFileStore\JsonFileStore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/JsonFileStore.Tests/JsonFileStoreTests.cs
+++ b/JsonFileStore.Tests/JsonFileStoreTests.cs
@@ -1,0 +1,162 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace JsonFileStore.Tests;
+
+public record TestItem(string Name, int Value);
+
+[JsonSerializable(typeof(List<TestItem>))]
+internal partial class TestSourceGenerationContext : JsonSerializerContext;
+
+public class JsonFileStoreTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _filePath;
+
+    public JsonFileStoreTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "JsonFileStoreTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+        _filePath = Path.Combine(_tempDir, "test.json");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Constructor_NullFilePath_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new JsonFileStore<List<TestItem>>(null!, TestSourceGenerationContext.Default.ListTestItem));
+    }
+
+    [Fact]
+    public void Constructor_EmptyFilePath_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new JsonFileStore<List<TestItem>>("", TestSourceGenerationContext.Default.ListTestItem));
+    }
+
+    [Fact]
+    public void Constructor_NullTypeInfo_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new JsonFileStore<List<TestItem>>(_filePath, null!));
+    }
+
+    [Fact]
+    public void Load_FileDoesNotExist_ReturnsDefault()
+    {
+        var store = new JsonFileStore<List<TestItem>>(_filePath, TestSourceGenerationContext.Default.ListTestItem);
+
+        var result = store.Load();
+
+        Assert.Null(result);
+        Assert.True(store.IsPersistenceAvailable);
+    }
+
+    [Fact]
+    public void Save_ThenLoad_RoundTrips()
+    {
+        var store = new JsonFileStore<List<TestItem>>(_filePath, TestSourceGenerationContext.Default.ListTestItem);
+        var items = new List<TestItem> { new("Alpha", 1), new("Beta", 2) };
+
+        store.Save(items);
+        var loaded = store.Load();
+
+        Assert.NotNull(loaded);
+        Assert.Equal(2, loaded.Count);
+        Assert.Equal("Alpha", loaded[0].Name);
+        Assert.Equal(2, loaded[1].Value);
+    }
+
+    [Fact]
+    public void Save_CreatesDirectoryIfMissing()
+    {
+        var nestedPath = Path.Combine(_tempDir, "sub", "deep", "test.json");
+        var store = new JsonFileStore<List<TestItem>>(nestedPath, TestSourceGenerationContext.Default.ListTestItem);
+
+        store.Save([new("Item", 42)]);
+
+        Assert.True(File.Exists(nestedPath));
+    }
+
+    [Fact]
+    public void Save_NullData_Throws()
+    {
+        var store = new JsonFileStore<List<TestItem>>(_filePath, TestSourceGenerationContext.Default.ListTestItem);
+
+        Assert.Throws<ArgumentNullException>(() => store.Save(null!));
+    }
+
+    [Fact]
+    public void Load_CorruptFile_ReturnsDefaultAndDisablesPersistence()
+    {
+        File.WriteAllText(_filePath, "NOT VALID JSON{{{");
+        var store = new JsonFileStore<List<TestItem>>(_filePath, TestSourceGenerationContext.Default.ListTestItem);
+
+        var result = store.Load();
+
+        Assert.Null(result);
+        Assert.False(store.IsPersistenceAvailable);
+        Assert.True(File.Exists(_filePath + ".bak"));
+    }
+
+    [Fact]
+    public void Save_SkippedWhenPersistenceDisabled()
+    {
+        File.WriteAllText(_filePath, "CORRUPT");
+        var store = new JsonFileStore<List<TestItem>>(_filePath, TestSourceGenerationContext.Default.ListTestItem);
+
+        // Load corrupt file to disable persistence
+        store.Load();
+        Assert.False(store.IsPersistenceAvailable);
+
+        // Clean up the .bak so we can verify Save is truly skipped
+        File.Delete(_filePath + ".bak");
+        if (File.Exists(_filePath)) File.Delete(_filePath);
+
+        store.Save([new("Should not persist", 0)]);
+
+        Assert.False(File.Exists(_filePath));
+    }
+
+    [Fact]
+    public void Save_OverwritesExistingFile()
+    {
+        var store = new JsonFileStore<List<TestItem>>(_filePath, TestSourceGenerationContext.Default.ListTestItem);
+
+        store.Save([new("First", 1)]);
+        store.Save([new("Second", 2), new("Third", 3)]);
+
+        var loaded = store.Load();
+        Assert.NotNull(loaded);
+        Assert.Equal(2, loaded.Count);
+        Assert.Equal("Second", loaded[0].Name);
+    }
+
+    [Fact]
+    public void Save_EmptyList_RoundTrips()
+    {
+        var store = new JsonFileStore<List<TestItem>>(_filePath, TestSourceGenerationContext.Default.ListTestItem);
+
+        store.Save([]);
+        var loaded = store.Load();
+
+        Assert.NotNull(loaded);
+        Assert.Empty(loaded);
+    }
+
+    [Fact]
+    public void IsPersistenceAvailable_TrueByDefault()
+    {
+        var store = new JsonFileStore<List<TestItem>>(_filePath, TestSourceGenerationContext.Default.ListTestItem);
+
+        Assert.True(store.IsPersistenceAvailable);
+    }
+}

--- a/JsonFileStore/JsonFileStore.cs
+++ b/JsonFileStore/JsonFileStore.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace JsonFileStore;
+
+public class JsonFileStore<T>
+{
+    private readonly string _filePath;
+    private readonly JsonTypeInfo<T> _typeInfo;
+
+    public bool IsPersistenceAvailable { get; private set; } = true;
+
+    public JsonFileStore(string filePath, JsonTypeInfo<T> typeInfo)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        ArgumentNullException.ThrowIfNull(typeInfo);
+
+        _filePath = filePath;
+        _typeInfo = typeInfo;
+    }
+
+    public T? Load()
+    {
+        try
+        {
+            if (!File.Exists(_filePath))
+            {
+                return default;
+            }
+
+            var json = File.ReadAllText(_filePath);
+            return JsonSerializer.Deserialize(json, _typeInfo);
+        }
+        catch (Exception ex)
+        {
+            IsPersistenceAvailable = false;
+            Console.WriteLine($"[JsonFileStore] Failed to load from '{_filePath}'. Continuing in memory-only mode. {ex.Message}");
+
+            try
+            {
+                if (File.Exists(_filePath))
+                {
+                    File.Move(_filePath, _filePath + ".bak", overwrite: true);
+                }
+            }
+            catch
+            {
+                // If backup fails, still continue in memory-only mode.
+            }
+
+            return default;
+        }
+    }
+
+    public void Save(T data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        if (!IsPersistenceAvailable)
+        {
+            return;
+        }
+
+        try
+        {
+            var directory = Path.GetDirectoryName(_filePath);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var json = JsonSerializer.Serialize(data, _typeInfo);
+            var tempPath = _filePath + ".tmp";
+
+            File.WriteAllText(tempPath, json);
+            File.Move(tempPath, _filePath, overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            IsPersistenceAvailable = false;
+            Console.WriteLine($"[JsonFileStore] Failed to save to '{_filePath}'. Continuing in memory-only mode. {ex.Message}");
+        }
+    }
+}

--- a/JsonFileStore/JsonFileStore.csproj
+++ b/JsonFileStore/JsonFileStore.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/RequesterMini.csproj
+++ b/RequesterMini.csproj
@@ -8,7 +8,7 @@
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   <PublishTrimmed>true</PublishTrimmed>
   <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
-  <DefaultItemExcludes>$(DefaultItemExcludes);CurlExporter\**;CurlExporter.Tests\**</DefaultItemExcludes>
+  <DefaultItemExcludes>$(DefaultItemExcludes);CurlExporter\**;CurlExporter.Tests\**;JsonFileStore\**;JsonFileStore.Tests\**</DefaultItemExcludes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,6 +17,8 @@
 
   <ItemGroup>
     <None Include=".github\copilot-instructions.md" />
+    <None Include="JsonFileStore.Tests\JsonFileStore.Tests.csproj" />
+    <None Include="JsonFileStore\JsonFileStore.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -34,5 +36,6 @@
 
   <ItemGroup>
     <ProjectReference Include="CurlExporter\CurlExporter.csproj" />
+    <ProjectReference Include="JsonFileStore\JsonFileStore.csproj" />
   </ItemGroup>
 </Project>

--- a/RequesterMini.sln
+++ b/RequesterMini.sln
@@ -9,6 +9,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CurlExporter", "CurlExporte
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CurlExporter.Tests", "CurlExporter.Tests\CurlExporter.Tests.csproj", "{3B027A0C-3559-43A2-B0C0-51E0A14D131B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JsonFileStore", "JsonFileStore\JsonFileStore.csproj", "{DCA12CD2-B001-43E3-A5AF-AAF48B888ED9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JsonFileStore.Tests", "JsonFileStore.Tests\JsonFileStore.Tests.csproj", "{308AA2FA-12BD-4EFC-BC9F-574F768BE391}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +59,30 @@ Global
 		{3B027A0C-3559-43A2-B0C0-51E0A14D131B}.Release|x64.Build.0 = Release|Any CPU
 		{3B027A0C-3559-43A2-B0C0-51E0A14D131B}.Release|x86.ActiveCfg = Release|Any CPU
 		{3B027A0C-3559-43A2-B0C0-51E0A14D131B}.Release|x86.Build.0 = Release|Any CPU
+		{DCA12CD2-B001-43E3-A5AF-AAF48B888ED9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DCA12CD2-B001-43E3-A5AF-AAF48B888ED9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DCA12CD2-B001-43E3-A5AF-AAF48B888ED9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DCA12CD2-B001-43E3-A5AF-AAF48B888ED9}.Debug|x64.Build.0 = Debug|Any CPU
+		{DCA12CD2-B001-43E3-A5AF-AAF48B888ED9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DCA12CD2-B001-43E3-A5AF-AAF48B888ED9}.Debug|x86.Build.0 = Debug|Any CPU
+		{DCA12CD2-B001-43E3-A5AF-AAF48B888ED9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DCA12CD2-B001-43E3-A5AF-AAF48B888ED9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DCA12CD2-B001-43E3-A5AF-AAF48B888ED9}.Release|x64.ActiveCfg = Release|Any CPU
+		{DCA12CD2-B001-43E3-A5AF-AAF48B888ED9}.Release|x64.Build.0 = Release|Any CPU
+		{DCA12CD2-B001-43E3-A5AF-AAF48B888ED9}.Release|x86.ActiveCfg = Release|Any CPU
+		{DCA12CD2-B001-43E3-A5AF-AAF48B888ED9}.Release|x86.Build.0 = Release|Any CPU
+		{308AA2FA-12BD-4EFC-BC9F-574F768BE391}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{308AA2FA-12BD-4EFC-BC9F-574F768BE391}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{308AA2FA-12BD-4EFC-BC9F-574F768BE391}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{308AA2FA-12BD-4EFC-BC9F-574F768BE391}.Debug|x64.Build.0 = Debug|Any CPU
+		{308AA2FA-12BD-4EFC-BC9F-574F768BE391}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{308AA2FA-12BD-4EFC-BC9F-574F768BE391}.Debug|x86.Build.0 = Debug|Any CPU
+		{308AA2FA-12BD-4EFC-BC9F-574F768BE391}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{308AA2FA-12BD-4EFC-BC9F-574F768BE391}.Release|Any CPU.Build.0 = Release|Any CPU
+		{308AA2FA-12BD-4EFC-BC9F-574F768BE391}.Release|x64.ActiveCfg = Release|Any CPU
+		{308AA2FA-12BD-4EFC-BC9F-574F768BE391}.Release|x64.Build.0 = Release|Any CPU
+		{308AA2FA-12BD-4EFC-BC9F-574F768BE391}.Release|x86.ActiveCfg = Release|Any CPU
+		{308AA2FA-12BD-4EFC-BC9F-574F768BE391}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Utils/SourceGenerationContext.cs
+++ b/Utils/SourceGenerationContext.cs
@@ -1,11 +1,13 @@
 
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using RequesterMini.ViewModels;
 
 namespace RequesterMini.Utils;
+
 [JsonSourceGenerationOptions(WriteIndented = true)]
 [JsonSerializable(typeof(OldRequestDto))]
+[JsonSerializable(typeof(List<OldRequestDto>))]
 internal partial class SourceGenerationContext : JsonSerializerContext
 {
-    
 }

--- a/ViewModels/OldRequestsWindowViewModel.cs
+++ b/ViewModels/OldRequestsWindowViewModel.cs
@@ -38,13 +38,21 @@ public class OldRequestsWindowViewModel : ViewModelBase
         "RequesterMini",
         "history.json");
 
-    private bool _persistenceAvailable = true;
+    private readonly JsonFileStore.JsonFileStore<List<OldRequestDto>> _store = new(
+        HistoryPath, SourceGenerationContext.Default.ListOldRequestDto);
 
     public ObservableCollection<OldRequestDto> OldRequests { get; } = [];
 
     public OldRequestsWindowViewModel()
     {
-        LoadHistory();
+        var items = _store.Load();
+        if (items is not null)
+        {
+            foreach (var item in items)
+            {
+                OldRequests.Add(item);
+            }
+        }
 
         MessageBus.Current.Listen<string>(Constants.MessageBusConstants.NewRequest).Subscribe(value =>
         {
@@ -57,77 +65,8 @@ public class OldRequestsWindowViewModel : ViewModelBase
             if (oldRequestObject is not null)
             {
                 OldRequests.Add(oldRequestObject);
-                SaveHistory();
+                _store.Save(OldRequests.ToList());
             }
         });
-    }
-
-    private void LoadHistory()
-    {
-        try
-        {
-            if (!File.Exists(HistoryPath))
-            {
-                return;
-            }
-
-            var json = File.ReadAllText(HistoryPath);
-            var items = JsonSerializer.Deserialize(json, SourceGenerationContext.Default.ListOldRequestDto);
-
-            if (items is null)
-            {
-                return;
-            }
-
-            foreach (var item in items)
-            {
-                OldRequests.Add(item);
-            }
-        }
-        catch (Exception ex)
-        {
-            _persistenceAvailable = false;
-            Console.WriteLine($"[RequesterMini] Failed to load request history. Continuing in memory-only mode. {ex.Message}");
-
-            try
-            {
-                if (File.Exists(HistoryPath))
-                {
-                    File.Move(HistoryPath, HistoryPath + ".bak", overwrite: true);
-                }
-            }
-            catch
-            {
-                // If backup fails, still continue in memory-only mode.
-            }
-        }
-    }
-
-    private void SaveHistory()
-    {
-        if (!_persistenceAvailable)
-        {
-            return;
-        }
-
-        try
-        {
-            var directory = Path.GetDirectoryName(HistoryPath);
-            if (!string.IsNullOrWhiteSpace(directory))
-            {
-                Directory.CreateDirectory(directory);
-            }
-
-            var json = JsonSerializer.Serialize(OldRequests.ToList(), SourceGenerationContext.Default.ListOldRequestDto);
-            var tempPath = HistoryPath + ".tmp";
-
-            File.WriteAllText(tempPath, json);
-            File.Move(tempPath, HistoryPath, overwrite: true);
-        }
-        catch (Exception ex)
-        {
-            _persistenceAvailable = false;
-            Console.WriteLine($"[RequesterMini] Failed to save request history. Continuing in memory-only mode. {ex.Message}");
-        }
     }
 }


### PR DESCRIPTION
## Summary
- persist old request history to local app data (`history.json`)
- load saved history on app startup
- add resilient error handling for missing file/permission/IO/invalid JSON cases
- switch to atomic file writes (`.tmp` then replace)
- add source-gen support for `List<OldRequestDto>`

## Notes
- app now falls back to in-memory mode if persistence fails, instead of crashing
- build passes locally with .NET 10
