### PR TITLE
Add load feature for old requests and UI improvements

### DIFF
--- a/Constants/MessageBusConstants.cs
+++ b/Constants/MessageBusConstants.cs
@@ -4,5 +4,6 @@
     {
         internal static readonly string NewJsonGenerated = "newjson";
         internal static readonly string NewRequest = "newrequest";
+        internal static readonly string LoadRequest = "loadrequest";
     }
 }

--- a/README.md
+++ b/README.md
@@ -4,15 +4,27 @@ Avalonia Base Http request Maker
 
 ## Generate Executable (for Smelly nerds)
 
-
-### Macos Publish
-```zsh
- dotnet publish -r osx-arm64  -p:PublishSingleFile=true --self-contained true
-```
+> Single-file + trimmed build is configured in the project. Just run the publish command.
 
 ### Windows Publish
 ```bash
-  dotnet publish -r win-x64  -p:PublishSingleFile=true --self-contained true
+dotnet publish -r win-x64 --self-contained true -c Release
 ```
+
+### macOS Publish
+```zsh
+dotnet publish -r osx-arm64 --self-contained true -c Release
+```
+
+### Distribution
+
+The following native files must be distributed **alongside** the exe:
+
+| File | Purpose |
+|---|---|
+| `av_libglesv2.dll` | Avalonia GPU/OpenGL rendering |
+| `libHarfBuzzSharp.dll` | Font shaping |
+| `libSkiaSharp.dll` | Skia graphics engine |
+
 ## Used Prompts
 - [For Styling](https://chat.openai.com/share/56bad6c9-9997-4f55-96d1-5b7714ede4be).

--- a/RequesterMini.csproj
+++ b/RequesterMini.csproj
@@ -7,6 +7,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   <PublishTrimmed>true</PublishTrimmed>
+  <PublishSingleFile>true</PublishSingleFile>
   <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
   <DefaultItemExcludes>$(DefaultItemExcludes);CurlExporter\**;CurlExporter.Tests\**;JsonFileStore\**;JsonFileStore.Tests\**;AppLogger\**;AppLogger.Tests\**</DefaultItemExcludes>
   </PropertyGroup>
@@ -32,6 +33,14 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="ReactiveUI.Avalonia" Version="11.3.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <TrimmerRootAssembly Include="ReactiveUI" />
+    <TrimmerRootAssembly Include="ReactiveUI.Avalonia" />
+    <TrimmerRootAssembly Include="DynamicData" />
+    <TrimmerRootAssembly Include="Splat" />
+    <TrimmerRootAssembly Include="System.Reactive" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ViewLocator.cs
+++ b/ViewLocator.cs
@@ -1,30 +1,33 @@
 using System;
+using System.Collections.Generic;
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using RequesterMini.ViewModels;
+using RequesterMini.Views;
 
 namespace RequesterMini;
 
 public class ViewLocator : IDataTemplate
 {
+    private static readonly Dictionary<Type, Func<Control>> _map = new()
+    {
+        { typeof(OldRequestsWindowViewModel), () => new OldRequestWindow() },
+        { typeof(JsonVisualizerWindowViewModel), () => new JsonVisualizerWindow() },
+    };
 
     public Control? Build(object? data)
     {
-        if (data is null){
+        if (data is null)
             return null;
-        }
-        
-        var name = data.GetType().FullName!.Replace("ViewModel", "View", StringComparison.Ordinal);
-        var type = Type.GetType(name);
 
-        if (type != null)
+        if (_map.TryGetValue(data.GetType(), out var factory))
         {
-            var control = (Control)Activator.CreateInstance(type)!;
+            var control = factory();
             control.DataContext = data;
             return control;
         }
-        
-        return new TextBlock { Text = "Not Found: " + name };
+
+        return new TextBlock { Text = "Not Found: " + data.GetType().FullName };
     }
 
     public bool Match(object? data)

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -44,9 +44,17 @@ public class MainWindowViewModel : ViewModelBase
     internal string SelectedBodyType { get; set; } = HttpConstants.SelectedBodyType;
 
 
-    internal string Url { get; set; } = HttpConstants.StartUrl;
+    internal string Url
+    {
+        get;
+        set => this.RaiseAndSetIfChanged(ref field, value);
+    } = HttpConstants.StartUrl;
 
-    internal string Body { get; set; } = "";
+    internal string Body
+    {
+        get;
+        set => this.RaiseAndSetIfChanged(ref field, value);
+    } = "";
 
 
     internal string ResponseStatusCode
@@ -122,6 +130,28 @@ public class MainWindowViewModel : ViewModelBase
 
             var curl = builder.Build();
             CopyToClipboard.Handle(curl).Subscribe();
+        });
+
+        MessageBus.Current.Listen<string>(MessageBusConstants.LoadRequest).Subscribe(value =>
+        {
+            if (value == null) return;
+
+            var dto = JsonSerializer.Deserialize<OldRequestDto>(value, SourceGenerationContext.Default.OldRequestDto);
+            if (dto is null) return;
+
+            Url = dto.Url;
+            SelectedHttpMethod = dto.Method;
+            Body = dto.Body;
+            ResponseStatusCode = dto.ResponseStatusCode;
+            ResponseBody = dto.ResponseBody;
+
+            Headers.Clear();
+            foreach (var kvp in dto.Headers)
+            {
+                var headerItem = new HeaderItem { Key = kvp.Key, Value = kvp.Value };
+                headerItem.OnRemove = RemoveHeader;
+                Headers.Add(headerItem);
+            }
         });
 
         ClickCommand = ReactiveCommand.CreateFromTask(async () =>

--- a/ViewModels/OldRequestsWindowViewModel.cs
+++ b/ViewModels/OldRequestsWindowViewModel.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reactive;
 using ReactiveUI;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -43,8 +45,25 @@ public class OldRequestsWindowViewModel : ViewModelBase
 
     public ObservableCollection<OldRequestDto> OldRequests { get; } = [];
 
+    internal ReactiveCommand<OldRequestDto, Unit> RemoveCommand { get; }
+
+    internal ReactiveCommand<OldRequestDto, Unit> LoadCommand { get; }
+
+    [RequiresUnreferencedCode("Uses ReactiveCommand")]
     public OldRequestsWindowViewModel()
     {
+        RemoveCommand = ReactiveCommand.Create<OldRequestDto>(item =>
+        {
+            OldRequests.Remove(item);
+            _store.Save(OldRequests.ToList());
+        });
+
+        LoadCommand = ReactiveCommand.Create<OldRequestDto>(item =>
+        {
+            var json = JsonSerializer.Serialize(item, SourceGenerationContext.Default.OldRequestDto);
+            MessageBus.Current.SendMessage(json, Constants.MessageBusConstants.LoadRequest);
+        });
+
         var items = _store.Load();
         if (items is not null)
         {

--- a/Views/OldRequestWindow.axaml
+++ b/Views/OldRequestWindow.axaml
@@ -13,32 +13,50 @@
     
     <Grid RowDefinitions="Auto, *">
         <TextBlock Text="History" FontWeight="Bold" FontSize="18" Margin="10"/>
-        
-        <ListBox Grid.Row="1" ItemsSource="{Binding OldRequests}" Background="Transparent" BorderThickness="0">
-            <ListBox.ItemTemplate>
-                <DataTemplate>
-                    <Grid ColumnDefinitions="Auto, *">
-                        <Border Grid.Column="0" 
-                                CornerRadius="3" 
-                                Background="{Binding MethodColor}"
-                                Padding="6,3"
-                                Margin="0,0,10,0"
-                                VerticalAlignment="Center"
-                                MinWidth="45">
-                            <TextBlock Text="{Binding Method}" 
-                                       FontWeight="Bold" 
-                                       FontSize="11"
-                                       Foreground="White"
-                                       HorizontalAlignment="Center"/>
-                        </Border>
-                        <TextBlock Grid.Column="1" 
-                                   Text="{Binding Url}" 
-                                   TextTrimming="CharacterEllipsis" 
-                                   VerticalAlignment="Center"
-                                   ToolTip.Tip="{Binding Url}"/>
-                    </Grid>
-                </DataTemplate>
-            </ListBox.ItemTemplate>
-        </ListBox>
+
+        <ScrollViewer Grid.Row="1">
+            <ItemsControl ItemsSource="{Binding OldRequests}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="vm:OldRequestDto">
+                        <Grid ColumnDefinitions="Auto, *, Auto" Margin="4,2">
+                            <Border Grid.Column="0" 
+                                    CornerRadius="3" 
+                                    Background="{Binding MethodColor}"
+                                    Padding="6,3"
+                                    Margin="0,0,10,0"
+                                    VerticalAlignment="Center"
+                                    MinWidth="45">
+                                <TextBlock Text="{Binding Method}" 
+                                           FontWeight="Bold" 
+                                           FontSize="11"
+                                           Foreground="White"
+                                           HorizontalAlignment="Center"/>
+                            </Border>
+                            <Button Grid.Column="1"
+                                    Command="{Binding $parent[UserControl].((vm:OldRequestsWindowViewModel)DataContext).LoadCommand}"
+                                    CommandParameter="{Binding}"
+                                    Background="Transparent"
+                                    Padding="0"
+                                    Cursor="Hand"
+                                    HorizontalAlignment="Stretch"
+                                    HorizontalContentAlignment="Left"
+                                    VerticalAlignment="Center">
+                                <TextBlock Text="{Binding Url}" 
+                                           TextTrimming="CharacterEllipsis"
+                                           ToolTip.Tip="{Binding Url}"/>
+                            </Button>
+                            <Button Grid.Column="2"
+                                    Command="{Binding $parent[UserControl].((vm:OldRequestsWindowViewModel)DataContext).RemoveCommand}"
+                                    CommandParameter="{Binding}"
+                                    Content="🗑"
+                                    Background="Transparent"
+                                    Padding="6,3"
+                                    Margin="6,0,0,0"
+                                    VerticalAlignment="Center"/>
+                        </Grid>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
     </Grid>
 </UserControl>


### PR DESCRIPTION
Introduced "Load" functionality for old requests via message bus. Added RemoveCommand and LoadCommand to OldRequestsWindowViewModel for deleting and loading requests. Updated history UI with load and delete buttons. Refactored ViewLocator for view mapping. Configured project for single-file, trimmed publishing and updated README with clearer instructions and distribution requirements.