### PR TITLE
Update screenshot path in README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ The following screenshot shows the main UI of RequesterMini. Add the image file 
 
 ![RequesterMini screenshot](docs/screenshot.png)
 
-If the image does not appear, place your screenshot at `docs/screenshot.png` (or update the path above) and commit the file.
+If the image does not appear, place your screenshot at `docs/reqesutermini.png` (or update the path above) and commit the file.


### PR DESCRIPTION
Changed guidance to reference docs/reqesutermini.png instead of docs/screenshot.png for the main UI screenshot. Users are now instructed to place the image at the new path if it does not appear.